### PR TITLE
1.5.1: Thymeleaf_商品一覧画面 #34

### DIFF
--- a/src/main/java/com/javajo/javajo_jewels/controller/ProductController.java
+++ b/src/main/java/com/javajo/javajo_jewels/controller/ProductController.java
@@ -1,23 +1,29 @@
 package com.javajo.javajo_jewels.controller;
 
 import com.javajo.javajo_jewels.model.Product;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@RestController
-@RequestMapping("api/products")
+@Controller
+@RequestMapping("/products")
 public class ProductController {
 
     @GetMapping
-    public List<Product> getProducts() {
+    public String products(Model model) {
         System.out.println("called getProducts");
-        List<Product> response = new ArrayList<>();
-        response.add(createProduct(1));
-        response.add(createProduct(2));
-        response.add(createProduct(3));
-        return response;
+
+        List<Product> products = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            products.add(createProduct(i + 1));
+        }
+
+        model.addAttribute("products", products);
+
+        return "products";
     }
 
     @GetMapping("/{id}")
@@ -31,6 +37,8 @@ public class ProductController {
         product.setId(id);
         product.setName("商品"+ id);
         product.setDescription("商品" + id + "の説明");
+        product.setPrice(3400);
+        product.setImageUrl("https://sunho.store/cdn/shop/files/968615.jpg?v=1745974078");
         return product;
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,4 +17,4 @@ spring.h2.console.path=/h2-console
 ##################################################
 # Thymeleaf
 spring.thymeleaf.cache=false
-spring.thymeleaf.prefix=classpath:/templates
+spring.thymeleaf.prefix=classpath:/templates/

--- a/src/main/resources/static/css/products.css
+++ b/src/main/resources/static/css/products.css
@@ -1,0 +1,64 @@
+.header {
+  height: 64px;
+  border-bottom: solid rgba(18, 18, 18, 0.08) 1px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.header-contents {
+  display: flex;
+  justify-content: space-between;
+  width: 1200px;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.javajo-jewels {
+  color: #D32D71;
+  font-weight: 700;
+  font-size: 24px;
+}
+
+.cart-icon {
+  width: 24px;
+}
+
+.main {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 48px;
+}
+
+.main-contents {
+  width: 1200px;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.title {
+  border-left: solid #D5C9BB 4px;
+  padding-left: 8px;
+  font-size: 24px;
+}
+
+.products {
+  margin-top: 32px;
+  margin-bottom: 48px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  row-gap: 24px;
+}
+
+.product {
+  width: 128px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.product-title {
+  font-size: 14px;
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1,0 +1,9 @@
+*,*::before,*::after{box-sizing:border-box}html{-moz-text-size-adjust:none;-webkit-text-size-adjust:none;text-size-adjust:none}body,h1,h2,h3,h4,p,figure,blockquote,dl,dd{margin:0}ul[role='list'],ol[role='list']{list-style:none}body{min-height:100vh;line-height:1.5}h1,h2,h3,h4,button,input,label{line-height:1.1}h1,h2,h3,h4{text-wrap:balance}a:not([class]){text-decoration-skip-ink:auto;color:currentColor}img,picture{max-width:100%;display:block}input,button,textarea,select{font:inherit}textarea:not([rows]){min-height:10em}:target{scroll-margin-block:5ex}
+
+html {
+  font-size: 16px;
+}
+
+a {
+  text-decoration: none;
+}

--- a/src/main/resources/static/images/shopping-cart.svg
+++ b/src/main/resources/static/images/shopping-cart.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
+</svg>

--- a/src/main/resources/templates/products.html
+++ b/src/main/resources/templates/products.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <link th:href="@{/css/style.css}" rel="stylesheet">
+    <link th:href="@{/css/products.css}" rel="stylesheet">
+</head>
+<body>
+<header class="header">
+    <div class="header-contents">
+        <div class="javajo-jewels">Java女宝石</div>
+        <a href=""><img class="cart-icon" th:src="@{/images/shopping-cart.svg}"/></a>
+    </div>
+</header>
+
+<main class="main">
+    <div class="main-contents">
+        <h1 class="title">全ての商品</h1>
+
+        <div class="products">
+            <a th:href="|/products/${product.id}|" th:each="product : ${products}">
+                <div class="product">
+                    <img th:src="${product.imageUrl}"/>
+                    <div class="product-title" th:text="${product.name}"></div>
+                    <div th:text="|¥${#numbers.formatInteger(product.price, 3, 'COMMA')}|"></div>
+                </div>
+            </a>
+        </div>
+    </div>
+</main>
+</body>
+</html>


### PR DESCRIPTION
一通り商品一覧画面作りました！
https://github.com/java-women/techbookfest_2025/issues/34

アイコンはここの使ってます
https://heroicons.com/

styleはベースのstyle.cssを読み込んで（全画面で読み込む）、商品一覧画面用のproducts.cssを読み込む形にしました。

こんな感じです。一旦、Figmaのやつに寄せた感じ！和訳のサービス名決まってないことに気づいて適当に入れてます、いいのあったら案ください！
<img width="1378" alt="スクリーンショット 2025-05-02 22 16 03" src="https://github.com/user-attachments/assets/f9a332a4-2d65-48b3-96c1-8cb4c3ab142d" />

脳停止で書いたらレスポンシブになったので勝手にスマホ対応みたいになっちゃいましたwwww
<img width="500" alt="スクリーンショット 2025-05-02 22 16 17" src="https://github.com/user-attachments/assets/756c5f76-418f-484d-b53a-30ad65f2d4fb" />

確認お願いします！